### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -13,7 +13,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   tenant      = module.iam_roles.global_tenant_name
   environment = module.iam_roles.global_environment_name
   stage       = module.iam_roles.global_stage_name

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -71,3 +71,9 @@ variable "audit_access_enabled" {
   default     = false
   description = "If `true`, allows the Audit account access to read Cloudtrail logs directly from S3. This is a requirement for running Athena queries in the Audit account."
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of a account-map component"
+  default     = "account-map"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variables `account_map_component_name`.
* Variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to set the account map component name through a new variable, allowing greater flexibility in customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->