### PR TITLE
feat: add `log_class_group` parameter to `aws_cloudwatch_log_group`

### DIFF
--- a/src/cloudtrail-cloudwatch-logs.tf
+++ b/src/cloudtrail-cloudwatch-logs.tf
@@ -63,5 +63,6 @@ resource "aws_cloudwatch_log_group" "cloudtrail_cloudwatch_logs" {
   count             = local.enabled ? 1 : 0
   name              = module.this.id
   retention_in_days = var.cloudwatch_logs_retention_in_days
+  log_group_class   = var.cloudwatch_log_group_class
   tags              = module.this.tags
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -12,10 +12,10 @@ variable "cloudwatch_logs_retention_in_days" {
 variable "cloudwatch_log_group_class" {
   type        = string
   default     = "STANDARD"
-  description = "Specifies the log class of the log group. Possible values are: STANDARD, INFREQUENT_ACCESS, or DELIVERY."
+  description = "Specifies the log class of the log group. Possible values are STANDARD or INFREQUENT_ACCESS."
   validation {
-    condition     = contains(["STANDARD", "INFREQUENT_ACCESS", "DELIVERY"], var.cloudwatch_log_group_class)
-    error_message = "The cloudwatch_log_group_class must be one of the following values: STANDARD, INFREQUENT_ACCESS, or DELIVERY."
+    condition     = contains(["STANDARD", "INFREQUENT_ACCESS"], var.cloudwatch_log_group_class)
+    error_message = "The cloudwatch_log_group_class must be STANDARD or INFREQUENT_ACCESS."
   }
 }
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -9,6 +9,16 @@ variable "cloudwatch_logs_retention_in_days" {
   description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
 }
 
+variable "cloudwatch_log_group_class" {
+  type        = string
+  default     = "STANDARD"
+  description = "Specifies the log class of the log group. Possible values are: STANDARD, INFREQUENT_ACCESS, or DELIVERY."
+  validation {
+    condition     = contains(["STANDARD", "INFREQUENT_ACCESS", "DELIVERY"], var.cloudwatch_log_group_class)
+    error_message = "The cloudwatch_log_group_class must be one of the following values: STANDARD, INFREQUENT_ACCESS, or DELIVERY."
+  }
+}
+
 variable "enable_logging" {
   type        = bool
   default     = true

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      version = ">= 5.30.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
## Why

- The `aws_cloudwatch_log_group` supports the `log_group_class` parameter, which allows users to specify the class of the log group, such as Standard or Infrequent Access. This is useful for optimizing costs based on the access patterns of the logs. Adding this improvement to our Terraform module will enhance its functionality and provide users with more control over their log group configurations.

## What

- This pull request updates the CloudTrail Terraform module to support the new `log_group_class` feature for CloudWatch Log Groups and raises the minimum required AWS provider version.
* Increased the minimum required AWS provider version from `>= 4.9.0` to `>= 5.30.0` in `versions.tf` and the documentation to support the new log group class feature.
* Added a new variable `cloudwatch_log_group_class` with validation, allowing users to specify the log group class as `STANDARD` or `INFREQUENT_ACCESS`.
* Updated the `aws_cloudwatch_log_group` resource to use the new `log_group_class` variable.
* Documented the new `cloudwatch_log_group_class` input variable in `README.md`, including its description and default value.

---

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

### Usage

```sh
atmos terraform apply cloudtrail -s <stack>
``` 

## Testing

- [X] Validated with `atmos validate stacks`
- [X] Performed successful `atmos terraform plan` on component

## References

- [Resource Docs](https://registry.terraform.io/providers/hashicorp/aws/5.30.0/docs/resources/cloudwatch_log_group)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable CloudWatch Logs log group class for CloudTrail (values: STANDARD, INFREQUENT_ACCESS; default: STANDARD).
  * Input validation with clear error messaging for allowed values.

* **Chores**
  * Bump minimum AWS provider requirement to v5.30.0 to ensure compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->