### PR TITLE
feat(kms): add ABAC support for CloudTrail KMS key

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -87,3 +87,38 @@ variable "account_map_component_name" {
   description = "The name of a account-map component"
   default     = "account-map"
 }
+
+variable "kms_key_alias" {
+  type        = string
+  description = "The alias for the KMS key. If not set, the alias will be set to `alias/<module.this.id>`"
+  default     = null
+}
+
+variable "kms_key_enabled" {
+  type        = bool
+  description = "Toggle to enable/disable the encrypted log group feature that has not been extensively tested."
+  default     = false
+}
+
+variable "kms_abac_statements" {
+  type = list(object({
+    sid        = optional(string)
+    effect     = string
+    actions    = list(string)
+    principals = map(list(string))
+    conditions = list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    }))
+  }))
+  description = <<-EOT
+    A list of ABAC statements which are placed in an IAM policy.
+    Each statement must have the following attributes:
+    - `sid` (optional): A unique identifier for the statement.
+    - `effect`: The effect of the statement. Valid values are `Allow` and `Deny`.
+    - `actions`: A list of actions to allow or deny.
+    - `conditions`: A list of conditions to evaluate when the statement is applied.
+  EOT
+  default     = []
+}


### PR DESCRIPTION
## what and why

- Thisadds support for Attribute-Based Access Control (ABAC) policies on the KMS key used by CloudTrail, along with new configuration options for KMS key aliasing and enablement. The changes introduce new variables to allow users to customize KMS key behavior and to define custom ABAC policy statements, which are then used to generate and attach an IAM policy to the KMS key when enabled.

---

* Added new variables in `src/variables.tf` to configure the KMS key alias (`kms_key_alias`), enable or disable the KMS key (`kms_key_enabled`), and provide a list of ABAC policy statements (`kms_abac_statements`).
* Defined new local variables in `src/cloudtrail-kms-key.tf` for `kms_key_alias` (with a default fallback), and a flag for whether ABAC is enabled based on the presence of ABAC statements.
* Added a new `aws_iam_policy_document` data block to generate ABAC policy statements dynamically from the provided list, including support for custom conditions and alias-based resource scoping.
* Added a new `aws_iam_policy` resource to create and attach the generated ABAC policy to the KMS key, conditional on the KMS key and ABAC being enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional ABAC support for the CloudTrail KMS key, enabling fine-grained, alias-scoped access control via declarative statements.
  - Introduced configurable KMS key alias (custom or sensible default) and a toggle to enable the KMS key feature.
  - Automatically generates and applies an IAM policy when ABAC is enabled, based on user-provided statements.
  - New inputs: alias configuration, enable/disable flag, and a structured list of ABAC statements with conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->