### PR TITLE
feat: add account_map_enabled variable for static account mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ github/
 *.ovpn
 
 *.zip
+
+# Vendored dependencies (used for testing)
+account-map/

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,3 +1,30 @@
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-EOT
+    When true, uses the account-map component to look up account IDs dynamically.
+    When false, uses the static account_map variable instead. Set to false when
+    using Atmos Auth profiles and static account mappings.
+    EOT
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map           = map(string)
+    audit_account_account_name = optional(string, "")
+    root_account_account_name  = optional(string, "")
+  })
+  description = <<-EOT
+    Static account map used when account_map_enabled is false.
+    Provides account name to account ID mapping without requiring the account-map component.
+    EOT
+  default = {
+    full_account_map           = {}
+    audit_account_account_name = ""
+    root_account_account_name  = ""
+  }
+}
+
 provider "aws" {
   region = var.region
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -9,14 +9,28 @@ module "cloudtrail_bucket" {
   context = module.this.context
 }
 
+# Remote state lookup for the account-map component (or fallback to static mapping).
+#
+# When account_map_enabled is true:
+#   - Performs remote state lookup to retrieve account mappings from the account-map component
+#   - Uses global tenant/environment/stage from iam_roles module for the lookup
+#
+# When account_map_enabled is false:
+#   - Bypasses the remote state lookup (bypass = true)
+#   - Returns the static account_map variable as defaults instead
+#   - Allows the component to function without the account-map dependency
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
   component   = var.account_map_component_name
-  tenant      = module.iam_roles.global_tenant_name
-  environment = module.iam_roles.global_environment_name
-  stage       = module.iam_roles.global_stage_name
+  tenant      = var.account_map_enabled ? module.iam_roles.global_tenant_name : null
+  environment = var.account_map_enabled ? module.iam_roles.global_environment_name : null
+  stage       = var.account_map_enabled ? module.iam_roles.global_stage_name : null
 
   context = module.this.context
+
+  # When account_map is disabled, bypass remote state and use the static account_map variable
+  bypass   = !var.account_map_enabled
+  defaults = var.account_map
 }

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -17,22 +17,30 @@ type ComponentSuite struct {
 	helper.TestSuite
 }
 
+const (
+	testStack    = "default-test"
+	testAwsRegion = "us-east-2"
+)
+
+// TearDownSuite empties the S3 bucket before the dependency is destroyed.
+// This is necessary because the bucket has versioning enabled and may contain
+// objects from CloudTrail logging during the tests.
+func (s *ComponentSuite) TearDownSuite() {
+	cloudtrailBucketOptions := s.GetAtmosOptions("cloudtrail-bucket", testStack, nil)
+	bucketName := atmos.Output(s.T(), cloudtrailBucketOptions, "cloudtrail_bucket_id")
+	aws.EmptyS3Bucket(s.T(), testAwsRegion, bucketName)
+}
+
 func (s *ComponentSuite) TestBasic() {
 	const component = "cloudtrail/basic"
-	const stack = "default-test"
-	const awsRegion = "us-east-2"
 
-	defer s.DestroyAtmosComponent(s.T(), component, stack, nil)
-	options, _ := s.DeployAtmosComponent(s.T(), component, stack, nil)
+	defer s.DestroyAtmosComponent(s.T(), component, testStack, nil)
+	options, _ := s.DeployAtmosComponent(s.T(), component, testStack, nil)
 	assert.NotNil(s.T(), options)
-
-	cloudtrailBucketOptions := s.GetAtmosOptions("cloudtrail-bucket", stack, nil)
-	bucketName := atmos.Output(s.T(), cloudtrailBucketOptions, "cloudtrail_bucket_id")
-	defer aws.EmptyS3Bucket(s.T(), awsRegion, bucketName)
 
 	cloudtrailID := atmos.Output(s.T(), options, "cloudtrail_id")
 
-	client := awshelper.NewCloudTrailClient(s.T(), awsRegion)
+	client := awshelper.NewCloudTrailClient(s.T(), testAwsRegion)
 	trails, err := client.DescribeTrails(context.Background(), &cloudtrail.DescribeTrailsInput{
 		TrailNameList: []string{cloudtrailID},
 	})
@@ -55,31 +63,25 @@ func (s *ComponentSuite) TestBasic() {
 	assert.True(s.T(), strings.HasSuffix(cloudtrailLogsRoleArn, cloudtrailLogsRoleName))
 
 	cloudtrailHomeRegion := atmos.Output(s.T(), options, "cloudtrail_home_region")
-	assert.Equal(s.T(), "us-east-2", cloudtrailHomeRegion)
+	assert.Equal(s.T(), testAwsRegion, cloudtrailHomeRegion)
 	assert.Equal(s.T(), *trail.HomeRegion, cloudtrailHomeRegion)
 
 	assert.False(s.T(), *trail.IsOrganizationTrail)
 
-	s.DriftTest(component, stack, nil)
+	s.DriftTest(component, testStack, nil)
 }
 
 func (s *ComponentSuite) TestOrgLevel() {
 	const component = "cloudtrail/org-level"
-	const stack = "default-test"
-	const awsRegion = "us-east-2"
 
 	s.T().Skip("Skipping org-level test because it's not supported due to Service Policy limitations")
-	defer s.DestroyAtmosComponent(s.T(), component, stack, nil)
-	options, _ := s.DeployAtmosComponent(s.T(), component, stack, nil)
+	defer s.DestroyAtmosComponent(s.T(), component, testStack, nil)
+	options, _ := s.DeployAtmosComponent(s.T(), component, testStack, nil)
 	assert.NotNil(s.T(), options)
-
-	cloudtrailBucketOptions := s.GetAtmosOptions("cloudtrail-bucket", stack, nil)
-	bucketName := atmos.Output(s.T(), cloudtrailBucketOptions, "cloudtrail_bucket_id")
-	defer aws.EmptyS3Bucket(s.T(), awsRegion, bucketName)
 
 	cloudtrailID := atmos.Output(s.T(), options, "cloudtrail_id")
 
-	client := awshelper.NewCloudTrailClient(s.T(), awsRegion)
+	client := awshelper.NewCloudTrailClient(s.T(), testAwsRegion)
 	trails, err := client.DescribeTrails(context.Background(), &cloudtrail.DescribeTrailsInput{
 		TrailNameList: []string{cloudtrailID},
 	})
@@ -102,24 +104,23 @@ func (s *ComponentSuite) TestOrgLevel() {
 	assert.True(s.T(), strings.HasSuffix(cloudtrailLogsRoleArn, cloudtrailLogsRoleName))
 
 	cloudtrailHomeRegion := atmos.Output(s.T(), options, "cloudtrail_home_region")
-	assert.Equal(s.T(), "us-east-2", cloudtrailHomeRegion)
+	assert.Equal(s.T(), testAwsRegion, cloudtrailHomeRegion)
 	assert.Equal(s.T(), *trail.HomeRegion, cloudtrailHomeRegion)
 
 	assert.True(s.T(), *trail.IsOrganizationTrail)
 
-	s.DriftTest(component, stack, nil)
+	s.DriftTest(component, testStack, nil)
 }
 
 func (s *ComponentSuite) TestEnabledFlag() {
 	const component = "cloudtrail/disabled"
-	const stack = "default-test"
 
-	s.VerifyEnabledFlag(component, stack, nil)
+	s.VerifyEnabledFlag(component, testStack, nil)
 }
 
 func TestRunSuite(t *testing.T) {
 	suite := new(ComponentSuite)
 
-	suite.AddDependency(t, "cloudtrail-bucket", "default-test", nil)
+	suite.AddDependency(t, "cloudtrail-bucket", testStack, nil)
 	helper.Run(t, suite)
 }


### PR DESCRIPTION

##  what

  - Add account_map_enabled variable to toggle between remote state lookup and static mapping
  - Add account_map variable for static account ID mapping
  - Update remote-state.tf to conditionally bypass account-map lookup when disabled

##  why

  - Enables cloudtrail component to function without the account-map component dependency
  - Supports deployments using Atmos Auth profiles and static account mappings

##  references

  - Part of account-map deprecation initiative
  - Supports Atmos Auth profile-based authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional account mapping to enable enhanced remote-state lookup using global IAM attributes, with a bypass/defaults mode when disabled.
* **Chores**
  * Added ignore rule for vendored dependency directory to keep repository clean.
* **Tests**
  * Improved test suite stability and cleanup by centralizing test stack/region settings and adding teardown cleanup for test artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->